### PR TITLE
Support scaladoc comments attached to models (case classes)

### DIFF
--- a/intermediate.scala
+++ b/intermediate.scala
@@ -8,7 +8,7 @@ object Type {
 }
 
 case class CaseClass(
-  name: String, members: List[CaseClass.Member])
+  name: String, members: List[CaseClass.Member], desc: Option[String])
 object CaseClass {
   case class Member(
     name: String, tpe: Type, desc: Option[String])

--- a/src/test/scala/extractors/Fixture.scala
+++ b/src/test/scala/extractors/Fixture.scala
@@ -56,6 +56,11 @@ object Fixture {
   |
   |package models
   |
+  |/**
+  | * Represents a camping site
+  | * @param name camping name
+  | * @param size number of tents
+  | */
   |case class Camping(name: String, size: Int)
   |""".stripMargin
 }

--- a/src/test/scala/extractors/ModelSuite.scala
+++ b/src/test/scala/extractors/ModelSuite.scala
@@ -18,11 +18,18 @@ class ModelSuite extends FunSuite {
     assert(result ===
       List(
         CaseClass(
-          "Camping",
-          List(
-            CaseClass.Member("name", Type.Name("String"), None),
-            CaseClass.Member("size", Type.Name("Int"), None)
-          )
+          name = "Camping",
+          members = List(
+            CaseClass.Member(
+              name = "name",
+              tpe = Type.Name("String"),
+              desc = Some("camping name")),
+            CaseClass.Member(
+              name = "size",
+              tpe = Type.Name("Int"),
+              desc = Some("number of tents"))
+          ),
+          desc = Some("Represents a camping site")
         )
       )
     )


### PR DESCRIPTION
Enables metarpheus to read the scaladoc attached to case classes and emit the description and parameter doc in the output.

Test plan: test.