### PR TITLE
Refactor in preparation for config loading

### DIFF
--- a/extractors.scala
+++ b/extractors.scala
@@ -5,14 +5,27 @@ import scala.meta.dialects.Scala211
 
 package object extractors {
 
-  def parse(file: java.io.File): scala.meta.Source = file.parse[Source]
+  def extractFullAPI(
+    parsed: List[scala.meta.Source],
+    routeOverrides: Map[List[String], intermediate.Route]): intermediate.API = {
+
+    val models: List[intermediate.CaseClass] =
+      parsed.flatMap(extractors.model.extractModel)
+
+    val routes: List[intermediate.Route] = 
+      parsed.flatMap(extractors.route.extractAllRoutes(routeOverrides))
+
+    intermediate API(models, routes)
+  }
+
+  // shared utility functions for the extractors package
 
   /**
    * Extract all terms from a sequence of applications of an infix operator
    * (which translates to nested `ApplyInfix`es).
    * e.g. getAllInfix(t1 + t2 + t3 + t4, "+") results in List(t1, t2, t3, t4)
    */
-  def getAllInfix(ainfix: internal.ast.Term, op: String): List[internal.ast.Term] = {
+  private[extractors] def getAllInfix(ainfix: internal.ast.Term, op: String): List[internal.ast.Term] = {
     import scala.meta.internal.ast._
     ainfix match {
       case Term.ApplyInfix(subinfix: Term.ApplyInfix, Term.Name(`op`), Nil, List(term : Term)) =>
@@ -27,7 +40,7 @@ package object extractors {
    * Convert a scala-meta representation of a type to a metarpheus
    * intermediate representation
    */
-  def tpeToIntermediate(tpe: internal.ast.Type): intermediate.Type = tpe match {
+  private[extractors] def tpeToIntermediate(tpe: internal.ast.Type): intermediate.Type = tpe match {
     case name: scala.meta.internal.ast.Type.Name =>
       intermediate.Type.Name(name.value)
     case scala.meta.internal.ast.Type.Apply(name: scala.meta.internal.ast.Type.Name, args) =>

--- a/fixture/models.scala
+++ b/fixture/models.scala
@@ -8,5 +8,4 @@ package models
  * @param size number of tents
  */
 case class Camping(name: String, size: Int)
-""".stripMargin
 

--- a/fixture/models.scala
+++ b/fixture/models.scala
@@ -1,0 +1,12 @@
+package io.buildo.baseexample
+
+package models
+
+/**
+ * Represents a camping site
+ * @param name camping name
+ * @param size number of tents
+ */
+case class Camping(name: String, size: Int)
+""".stripMargin
+

--- a/fixture/routes.scala
+++ b/fixture/routes.scala
@@ -1,0 +1,48 @@
+package io.buildo.baseexample
+
+import morpheus.annotation.{publishroute, alias}
+
+import models._
+
+import spray.routing._
+import spray.routing.Directives._
+import spray.httpx.SprayJsonSupport._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+trait CampingRouterModule extends io.buildo.base.MonadicCtrlRouterModule
+  with io.buildo.base.MonadicRouterHelperModule
+  with io.buildo.base.ConfigModule
+  with JsonSerializerModule
+  
+  with CampingControllerModule {
+
+  import ExampleJsonProtocol._
+  import RouterHelpers._
+
+  /** whether there's a beach */
+  @alias val `?hasBeach` = parameter('hasBeach.as[Boolean])
+
+  @publishroute(authenticated = false)
+  val campingRoute = {
+    pathPrefix("campings") {
+      (get & pathEnd & parameters('coolness.as[String], 'size.as[Int].?) /**
+        get campings matching the requested coolness and size
+        @param coolness how cool it is
+        @param size the number of tents
+      */) (returns[List[Camping]].ctrl(campingController.getByCoolnessAndSize _)) ~
+      withUserAuthentication {
+        (get & path(IntNumber) /**
+          get a camping by id
+        */) (returns[Camping].ctrl(campingController.getById _)) ~
+      } ~
+      (get & pathEnd & `?hasBeach` /**
+        get campings based on whether they're close to a beach
+      */) (returns[List[Camping]].ctrl(campingController.getByHasBeach _)) ~
+      (post & pathEnd & entity(as[Camping]) /**
+        create a camping
+      */) (returns[Camping].ctrl(campingController.create _))
+    }
+  }
+}
+

--- a/main.scala
+++ b/main.scala
@@ -4,44 +4,31 @@ import java.io.File
 
 object main {
 
+  private def parse(file: java.io.File): scala.meta.Source = {
+    import scala.meta._
+    import scala.meta.dialects.Scala211
+    file.parse[Source]
+  }
+
   def main(argv: Array[String]) = {
     def recursivelyListFiles(f: File): Array[File] = {
-      val these = f.listFiles
+      val these: Array[java.io.File] = Option(f.listFiles).getOrElse(Array())
       these ++ these.filter(_.isDirectory).flatMap(recursivelyListFiles)
     }
 
-    val files = argv.map { (dir) =>
-      recursivelyListFiles(new File(dir))
+    val files = argv.map { dir =>
+      val file = new File(dir)
+      if (!file.exists) {
+        throw new Exception("The provided file or folder does not exist")
+      }
+      recursivelyListFiles(file)
     }.flatten.filter(_.getName.endsWith(".scala")).toList
 
-    val parsed: List[scala.meta.Source] = files.map(extractors.parse)
+    val parsed: List[scala.meta.Source] = files.map(parse)
 
-    val routes: List[intermediate.Route] = 
-      parsed.flatMap(extractors.route.extractAllRoutes(Map()) _) // TODO: load config file with route overrides
+    val routeOverrides: Map[List[String], intermediate.Route] = Map()
 
-    val modelsInUse: List[intermediate.Type] = {
-      import intermediate._
-      routes.flatMap { route =>
-        route.route.collect {
-          case RouteSegment.Param(routeParam) => routeParam.tpe
-        } ++
-        route.params.map(_.tpe) ++
-        List(route.returns) ++
-        route.body.map(b => List(b.tpe)).getOrElse(Nil)
-      }
-    }
-
-    val allConcreteTypesInUse: List[String] = {
-      def recurse(t: intermediate.Type): List[intermediate.Type.Name] = t match {
-        case name: intermediate.Type.Name => List(name)
-        case intermediate.Type.Apply(_, args) => args.flatMap(recurse).toList
-      }
-      modelsInUse.flatMap(recurse)
-    }.map(_.name)
-
-    val models: List[intermediate.CaseClass] =
-      parsed.flatMap(extractors.model.extractModel).filter(cc =>
-        allConcreteTypesInUse.contains(cc.name))
+    val api = extractors.extractFullAPI(parsed, routeOverrides).stripUnusedModels
 
     import org.json4s._
     import org.json4s.JsonDSL._
@@ -50,9 +37,7 @@ object main {
 
     implicit val formats = Serialization.formats(NoTypeHints)
 
-    val json =
-      ("models" -> Extraction.decompose(models)) ~
-      ("routes" -> Extraction.decompose(routes))
+    val json = Extraction.decompose(api)
 
     println(pretty(json))
   }

--- a/main.scala
+++ b/main.scala
@@ -30,16 +30,8 @@ object main {
 
     val api = extractors.extractFullAPI(parsed, routeOverrides).stripUnusedModels
 
-    import org.json4s._
-    import org.json4s.JsonDSL._
-    import org.json4s.jackson.JsonMethods._
-    import org.json4s.jackson.Serialization
+    println(repr.serializeAPI(api))
 
-    implicit val formats = Serialization.formats(NoTypeHints)
-
-    val json = Extraction.decompose(api)
-
-    println(pretty(json))
   }
 
 }

--- a/repr.scala
+++ b/repr.scala
@@ -1,0 +1,14 @@
+package morpheus
+
+package object repr {
+
+  import org.json4s._
+  import org.json4s.JsonDSL._
+  import org.json4s.jackson.JsonMethods._
+  import org.json4s.jackson.Serialization
+
+  implicit val formats = Serialization.formats(NoTypeHints)
+
+  def serializeAPI(api: intermediate.API): String = pretty(Extraction.decompose(api))
+
+}

--- a/src/test/scala/fixtures.scala
+++ b/src/test/scala/fixtures.scala
@@ -1,0 +1,10 @@
+package morpheus.extractors
+
+object Fixtures {
+  private def slurp(name: String) = {
+    val source = io.Source.fromFile(name)
+    try source.mkString finally source.close()
+  }
+  val models = slurp("fixture/models.scala")
+  val routes = slurp("fixture/routes.scala")
+}


### PR DESCRIPTION
* Move (de)serialization out of main

* Move extraction and filtering logic out of main

  - extracting a full API (models and routes) is moved to `extractors`
  - cutting down the models to only those in use is moved to
   `intermediate`

* Make fixtures into plain scala files so they can be used by integration
  tests