### PR TITLE
Support configurable auth routes names

### DIFF
--- a/extractor/config.scala
+++ b/extractor/config.scala
@@ -4,8 +4,11 @@ trait Config {
   val routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type]
 
   val routeOverrides: Map[List[String], intermediate.Route] = Map()
+
+  val authRouteTermNames: List[String] = Nil
 }
 
 object DefaultConfig extends Config {
   val routeMatcherToIntermediate = PartialFunction.empty
+  override val authRouteTermNames = List("withUserAuthentication")
 }

--- a/extractor/extractors.scala
+++ b/extractor/extractors.scala
@@ -8,7 +8,9 @@ package object extractors {
   def extractFullAPI(
     parsed: List[scala.meta.Source],
     routeOverrides: Map[List[String], intermediate.Route],
-    routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type]): intermediate.API = {
+    routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type],
+    authRouteTermNames: List[String]
+  ): intermediate.API = {
 
     val models: List[intermediate.Model] =
       parsed.flatMap(extractors.model.extractModel)
@@ -17,7 +19,7 @@ package object extractors {
       models.collect { case x: intermediate.CaseClass => x }
 
     val routes: List[intermediate.Route] =
-      parsed.flatMap(extractors.route.extractAllRoutes(caseClasses, routeOverrides, routeMatcherToIntermediate))
+      parsed.flatMap(extractors.route.extractAllRoutes(caseClasses, routeOverrides, routeMatcherToIntermediate, authRouteTermNames))
 
     intermediate API(models, routes)
   }

--- a/extractor/fixture/config.scala
+++ b/extractor/fixture/config.scala
@@ -19,4 +19,6 @@ new morpheus.Config {
       desc = Some("gets something"),
       name = List("campingController", "overridden")
     ))
+
+  override val authRouteTermNames = List("withUserAuthentication", "withRole")
 }

--- a/extractor/fixture/sources/routes.scala
+++ b/extractor/fixture/sources/routes.scala
@@ -60,7 +60,7 @@ trait CampingRouterModule extends io.buildo.base.MonadicCtrlRouterModule
         overridable route
         @name campingController.overridden
       */) (returns[Camping].ctrl(campingController.something _)) ~
-      withRole(Admin) {
+      withRole(Admin) { user =>
         (get & path("by_query") & params[GetByQueryParams] /**
           get multiple campings by params with case class
         */) (returns[List[Camping]].ctrl(campingController.getByQuery _))

--- a/extractor/fixture/sources/routes.scala
+++ b/extractor/fixture/sources/routes.scala
@@ -14,7 +14,7 @@ trait CampingRouterModule extends io.buildo.base.MonadicCtrlRouterModule
   with io.buildo.base.MonadicRouterHelperModule
   with io.buildo.base.ConfigModule
   with JsonSerializerModule
-  
+
   with CampingControllerModule {
 
   import ExampleJsonProtocol._
@@ -60,10 +60,11 @@ trait CampingRouterModule extends io.buildo.base.MonadicCtrlRouterModule
         overridable route
         @name campingController.overridden
       */) (returns[Camping].ctrl(campingController.something _)) ~
-      (get & path("by_query") & params[GetByQueryParams] /**
-        get multiple campings by params with case class
-      */) (returns[List[Camping]].ctrl(campingController.getByQuery _))
+      withRole(Admin) {
+        (get & path("by_query") & params[GetByQueryParams] /**
+          get multiple campings by params with case class
+        */) (returns[List[Camping]].ctrl(campingController.getByQuery _))
+      }
     }
   }
 }
-

--- a/extractor/main.scala
+++ b/extractor/main.scala
@@ -44,7 +44,9 @@ object main {
 
     val api = extractors.extractFullAPI(parsed,
       config.routeOverrides,
-      config.routeMatcherToIntermediate).stripUnusedModels
+      config.routeMatcherToIntermediate,
+      config.authRouteTermNames
+    ).stripUnusedModels
 
     val serializedAPI = repr.serializeAPI(api)
 

--- a/extractor/route.scala
+++ b/extractor/route.scala
@@ -55,7 +55,7 @@ package object route {
    * authenticated will be true if the "authenticated" param for @publishRoute
    * is true or if a "withUserAuthentication" directive has been encountered
    */
-  def extractRouteTerms(source: scala.meta.Source): List[RouteTermInfo] = {
+  def extractRouteTerms(source: scala.meta.Source, authRouteTermNames: List[String]): List[RouteTermInfo] = {
 
     val routesTerms: List[(Term, Boolean)] = // (term, authenticated)
       source.collect {
@@ -95,7 +95,7 @@ package object route {
 
       val routeTerms = getAllInfix(routesTerm, "~")
 
-      routeTerms.flatMap { 
+      routeTerms.flatMap {
         case Term.Apply(
           Term.Apply(
             Term.Name("pathPrefix"),
@@ -103,15 +103,19 @@ package object route {
           ),
           List(Term.Block(List(t : Term)))
         ) => recurse(prefix :+ addPrefix)(t, authenticated)
+        case x@(Term.Apply(
+          Term.Name(termName),
+          List(Term.Block(List(Term.Select(t : Term, _)))))
+        ) if authRouteTermNames.contains(termName) => recurse(prefix)(t, true)
         case Term.Apply(
-          Term.Name("withUserAuthentication"),
-          List(Term.Block(List(Term.Select(t : Term, _))))
-        ) => recurse(prefix)(t, true)
+          Term.Apply(Term.Name(termName), _),
+          List(Term.Block(List(t : Term)))
+        ) if authRouteTermNames.contains(termName) => recurse(prefix)(t, true)
         case Term.Apply(routeTpe : Term.ApplyInfix, List(routeTerm : Term)) =>
           List(
             RouteTermInfo(prefix, authenticated, routeTpe, routeTerm)
           )
-        case otherwise => println(otherwise.show[Structure]); ???
+        case otherwise => println(otherwise.show[Structure]); println(authRouteTermNames); ???
       }
     }
 
@@ -121,7 +125,7 @@ package object route {
   private case class TooFewMatches() extends Exception
   private case class TooManyMatches() extends Exception
   private implicit class ListPimp[A](list: List[A]) {
-    def getOne[B](pf: PartialFunction[A, B]) = 
+    def getOne[B](pf: PartialFunction[A, B]) =
       list.collect(pf) match {
         case List(one) => one
         case List() => throw TooFewMatches()
@@ -306,9 +310,9 @@ package object route {
 
   }
 
-  def extractAllRoutes(models: List[intermediate.CaseClass], overrides: Map[List[String], intermediate.Route], routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type])(f: scala.meta.Source): List[intermediate.Route] = {
+  def extractAllRoutes(models: List[intermediate.CaseClass], overrides: Map[List[String], intermediate.Route], routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type], authRouteTermNames: List[String])(f: scala.meta.Source): List[intermediate.Route] = {
     val aliases = extractAliases(f)
-    extractRouteTerms(f).map { routeTerm =>
+    extractRouteTerms(f, authRouteTermNames).map { routeTerm =>
       val routeCommentInfo = extractRouteCommentInfo(routeTerm.routeTpe)
       routeCommentInfo.routeName.flatMap(overrides.get _)
         .getOrElse(extractRoute(aliases, models, routeMatcherToIntermediate)(routeTerm, routeCommentInfo))

--- a/extractor/route.scala
+++ b/extractor/route.scala
@@ -101,16 +101,21 @@ package object route {
             Term.Name("pathPrefix"),
             List(Lit(addPrefix: String))
           ),
-          List(Term.Block(List(t : Term)))
+          List(Term.Block(List(t: Term)))
         ) => recurse(prefix :+ addPrefix)(t, authenticated)
         case x@(Term.Apply(
           Term.Name(termName),
-          List(Term.Block(List(Term.Select(t : Term, _)))))
+          List(Term.Block(List(Term.Select(t: Term, _)))))
         ) if authRouteTermNames.contains(termName) => recurse(prefix)(t, true)
         case Term.Apply(
           Term.Apply(Term.Name(termName), _),
-          List(Term.Block(List(t : Term)))
+          List(Term.Block(List(t: Term)))
         ) if authRouteTermNames.contains(termName) => recurse(prefix)(t, true)
+        case Term.Apply(
+          Term.Apply(Term.Name(termName), _),
+          List(Term.Block(List(t: Term)))
+        ) if authRouteTermNames.contains(termName) => recurse(prefix)(t, true)
+        case Term.Function(_, Term.Block(List(t: Term))) => recurse(prefix)(t, authenticated)
         case Term.Apply(routeTpe : Term.ApplyInfix, List(routeTerm : Term)) =>
           List(
             RouteTermInfo(prefix, authenticated, routeTpe, routeTerm)

--- a/extractor/src/test/scala/extractors/ApiSuite.scala
+++ b/extractor/src/test/scala/extractors/ApiSuite.scala
@@ -15,7 +15,7 @@ class ApiSuite extends FunSuite {
   test("extract used models") {
     import morpheus.intermediate._
 
-    val api = extractFullAPI(parsed, Common.overrides, Common.routeMatcherToTpe).stripUnusedModels
+    val api = extractFullAPI(parsed, Common.overrides, Common.routeMatcherToTpe, Common.authRouteTermNames).stripUnusedModels
 
     assert(api.models.collectFirst {
       case CaseEnum("CampingLocation", _, _) => ()

--- a/extractor/src/test/scala/extractors/Common.scala
+++ b/extractor/src/test/scala/extractors/Common.scala
@@ -28,4 +28,5 @@ object Common {
       case ("Id", Some(x@Type.Name(_))) => Type.Apply("Id", Seq(x))
     }
 
+    val authRouteTermNames = List("withUserAuthentication", "withRole")
 }

--- a/extractor/src/test/scala/extractors/RouteSuite.scala
+++ b/extractor/src/test/scala/extractors/RouteSuite.scala
@@ -19,7 +19,7 @@ class RouteSuite extends FunSuite {
 
     val models = model.extractModel(parsed)
     val caseClasses = models.collect { case x: morpheus.intermediate.CaseClass => x }
-    val result = extractAllRoutes(caseClasses, Common.overrides, Common.routeMatcherToTpe)(parsed)
+    val result = extractAllRoutes(caseClasses, Common.overrides, Common.routeMatcherToTpe, Common.authRouteTermNames)(parsed)
 
     assert(result.toString ===
       List(
@@ -148,7 +148,7 @@ class RouteSuite extends FunSuite {
               Some("the number of tents")
             )
           ),
-          authenticated = false,
+          authenticated = true,
           returns = Type.Apply("List", List(Type.Name("Camping"))),
           body = None,
           ctrl = List("campingController", "getByQuery"),


### PR DESCRIPTION
This PR aims at making the interpretation of the DSL a bit more configurable.

Specifically, we need to support directives other than `withUserAuthentication` for authentication, i.e. there's a project where we're using something like `withRole(Admin) { ... }`.

This PR makes the route names configurable. Currently only these formats are supported

```scala
termName { ... }
termName(...) { ... }
termName(...) { ... => ... }
```

Also, `withUserAuthentication` is inserted in the default config for retro-compatibility.