### PR TITLE
Add support for case class params extractors

### DIFF
--- a/extractor/fixture/sources/routes.scala
+++ b/extractor/fixture/sources/routes.scala
@@ -41,6 +41,11 @@ trait CampingRouterModule extends io.buildo.base.MonadicCtrlRouterModule
         @param size the number of tents
         @param nickname a friendly name for the camping
       */) (returns[List[Camping]].ctrl(campingController.getByCoolnessAndSize _)) ~
+      (get & pathEnd & parameters('size.as[Int], 'distance.as[Int]).as(Foo) /**
+        get campings matching the requested size and distance
+        @param size the number of tents
+        @param distance how distant it is
+      */) (returns[List[Camping]].ctrl(campingController.getBySizeAndDistance _)) ~
       withUserAuthentication {
         (get & path(IntNumber) /**
           get a camping by id

--- a/extractor/route.scala
+++ b/extractor/route.scala
@@ -217,6 +217,7 @@ package object route {
             case Lit(sym: Symbol) => Param(extractSimpleParamTerm(sym.name, aliasDesc))
             case Lit(name: String) => Param(extractSimpleParamTerm(name, aliasDesc))
           }
+        case Term.Apply(Term.Select(p, Term.Name("as")), _)  => extract(p, aliasDesc)
         case Term.ApplyType(Term.Name("params"), Seq(Type.Name(typeName))) =>
           models.find(_.name == typeName).get.members.map {
             case intermediate.CaseClass.Member(name, tpe, desc) =>
@@ -268,6 +269,7 @@ package object route {
             None)))
         case Term.Name(name) if aliases.contains(name) =>
           extract(aliases(name).term, aliasDesc = aliases(name).desc)
+        case otherwise => println(otherwise.show[Structure]); ???
       }
       extract(term, aliasDesc = None)
     }

--- a/extractor/src/test/scala/extractors/RouteSuite.scala
+++ b/extractor/src/test/scala/extractors/RouteSuite.scala
@@ -54,7 +54,32 @@ class RouteSuite extends FunSuite {
           ctrl = List("campingController", "getByCoolnessAndSize"),
           desc = Some("get campings matching the requested coolness and size"),
           name = List("campingController", "getByCoolnessAndSize")
-
+        ),
+        Route(
+          method = "get",
+          route = List(
+            RouteSegment.String("campings")
+          ),
+          params = List(
+            RouteParam(
+              Some("size"),
+              Type.Name("Int"),
+              true,
+              Some("the number of tents")
+            ),
+            RouteParam(
+              Some("distance"),
+              Type.Name("Int"),
+              true,
+              Some("how distant it is")
+            )
+          ),
+          authenticated = false,
+          returns = Type.Apply("List", List(Type.Name("Camping"))),
+          body = None,
+          ctrl = List("campingController", "getBySizeAndDistance"),
+          desc = Some("get campings matching the requested size and distance"),
+          name = List("campingController", "getBySizeAndDistance")
         ),
         Route(
           method = "get",


### PR DESCRIPTION
Add support for case class parameters extractors, e.g. appending `.as(Foo)` to parameter(s) directives

Example:

```scala
(get & pathEnd & parameters('size.as[Int], 'distance.as[Int]).as(Foo) /**
```

this currently throws a `MatchError`. This PR allows the syntax (and discards the case class information, as not relevant for routing purposes)