### PR TITLE
Add support for wiro

### DIFF
--- a/extractor/controller.scala
+++ b/extractor/controller.scala
@@ -1,0 +1,105 @@
+package morpheus
+package extractors
+
+import scala.meta._
+import scala.meta.dialects.Scala211
+
+package object controller {
+
+  private[this] def extractMethod(m: Decl.Def): String =
+    m.mods.collectFirst {
+      case Mod.Annot(Ctor.Ref.Name("query")) => "get"
+      case Mod.Annot(Ctor.Ref.Name("command")) => "post"
+    }.get
+
+  private[this] def extractAuthenticated(m: Decl.Def): Boolean =
+    m.mods.collectFirst {
+      case Mod.Annot(Ctor.Ref.Name("token")) => ()
+    }.nonEmpty
+
+  private[this] def extractParams(m: Decl.Def, paramsDesc: List[ParamDesc], inBody: Boolean): List[intermediate.RouteParam] = {
+    m.paramss.headOption.map { params => params.map { p =>
+
+      val (tpe, required) = p.decltpe.collectFirst {
+        case Type.Apply(Type.Name("Option"), Seq(t)) => (tpeToIntermediate(t), false)
+        case t: Type => (tpeToIntermediate(t), true)
+      }.head
+
+      val name = p.name.syntax
+      intermediate.RouteParam(
+        name = Option(p.name.syntax),
+        tpe = tpe,
+        required = required,
+        desc = paramsDesc.find(_.name == name).flatMap(_.desc),
+        inBody = inBody
+      )
+    }}.getOrElse(Nil).toList
+  }
+
+  private[this] def extractReturnType(m: Decl.Def): intermediate.Type =
+    m.decltpe.collect {
+      case Type.Apply(
+        Type.Name("Future"),
+        Seq(
+          Type.Apply(
+            Type.Name("Either"),
+            Seq(_, tpe)))) => tpeToIntermediate(tpe)
+    }.headOption.getOrElse(intermediate.Type.Name("UNKNOWN"))
+
+  def extractAllRoutes(source: Source): List[intermediate.Route] =
+    source.collect { case t: Defn.Trait => t }.flatMap(t => extractRoute(source, t))
+
+  def extractRoute(source: Source, t: Defn.Trait): List[intermediate.Route] = {
+    val methods = t.collect {
+      case m: Decl.Def if m.mods.collect {
+        case Mod.Annot(Ctor.Ref.Name("query" | "command")) => ()
+      }.nonEmpty => m
+    }
+
+    val (controllerName, name) = t.mods.collectFirst {
+      case Mod.Annot(
+        Term.Apply(
+          Ctor.Ref.Name("path"),
+          Seq(Lit(n: String)))) => (t.name.value, n)
+    }.getOrElse(t.name.value, t.name.value)
+
+    methods.map { m =>
+      val scaladoc = findRelatedComment(source, m)
+      val (desc, tagsDesc) = extractDescAndTagsFromComment(scaladoc)
+      val paramsDesc = tagsDesc.collect { case d: ParamDesc => d }
+      val method = extractMethod(m)
+      intermediate.Route(
+        method = method,
+        route = List(
+          intermediate.RouteSegment.String(name),
+          intermediate.RouteSegment.String(m.name.syntax)
+        ),
+        params = extractParams(m, paramsDesc, inBody = method == "post"),
+        authenticated = extractAuthenticated(m),
+        returns = extractReturnType(m),
+        // FIXME: this is the only case in which we don't preserve the retro-compatibility
+        // This is because intermediate.Body is too limiting as it assumes the body has a single Type
+        // whereas we want to support bodies composed by multiple parameters each with their own Type
+        // We're moving towards removing this node completely and instead merging the body params with
+        // params, flagging them with a new `inBody` property.
+        body = None,
+        ctrl = List(
+          // FIXME: well this is kind of a retrocompatibility hack
+          // When parsing the routes we use the actual name of the controller variable in scope
+          // whereas here's we're deriving it from the name of the trait. They should match in the
+          // usual case, nonetheless it may introduce some diffs when migrating a project to wiro
+          controllerName.substring(0, 1).toLowerCase() + controllerName.substring(1),
+          m.name.syntax
+        ),
+        desc = desc,
+        name = List(
+          // FIXME: same as a above, for the time being we preserved the `controllerName.method`
+          // semantic, but these should really be prefixed using `name` instead of `controllerName`
+          controllerName.substring(0, 1).toLowerCase() + controllerName.substring(1),
+          m.name.syntax
+        )
+      )
+    }
+  }
+
+}

--- a/extractor/controller.scala
+++ b/extractor/controller.scala
@@ -44,7 +44,15 @@ package object controller {
           Type.Apply(
             Type.Name("Either"),
             Seq(_, tpe)))) => tpeToIntermediate(tpe)
-    }.headOption.getOrElse(intermediate.Type.Name("UNKNOWN"))
+    }.headOption.getOrElse {
+        throw new Exception(s"""
+          |This method misses an explicit return type
+          |
+          |  ${m.syntax}
+          |
+          |It should be in the form of Future[Either[A, B]].
+        """.stripMargin)
+      }
 
   def extractAllRoutes(source: Source): List[intermediate.Route] =
     source.collect { case t: Defn.Trait => t }.flatMap(t => extractRoute(source, t))

--- a/extractor/extractors.scala
+++ b/extractor/extractors.scala
@@ -21,7 +21,11 @@ package object extractors {
       models.collect { case x: intermediate.CaseClass => x }
 
     val routes: List[intermediate.Route] =
-      parsed.flatMap(extractors.route.extractAllRoutes(caseClasses, routeOverrides, routeMatcherToIntermediate, authRouteTermNames))
+      if (wiro) {
+        parsed.flatMap(extractors.controller.extractAllRoutes)
+      } else {
+        parsed.flatMap(extractors.route.extractAllRoutes(caseClasses, routeOverrides, routeMatcherToIntermediate, authRouteTermNames))
+      }
 
     intermediate API(models, routes)
   }

--- a/extractor/extractors.scala
+++ b/extractor/extractors.scala
@@ -11,7 +11,8 @@ package object extractors {
     parsed: List[scala.meta.Source],
     routeOverrides: Map[List[String], intermediate.Route],
     routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type],
-    authRouteTermNames: List[String]
+    authRouteTermNames: List[String],
+    wiro: Boolean
   ): intermediate.API = {
 
     val models: List[intermediate.Model] =

--- a/extractor/fixture/sources/controllers.scala
+++ b/extractor/fixture/sources/controllers.scala
@@ -1,0 +1,81 @@
+package io.buildo.baseexample
+
+package controllers
+
+import models._
+
+import wiro.annotation._
+
+import scala.concurrent.{ Future, ExecutionContext }
+
+@name("campings")
+trait CampingController {
+  /**
+   * get campings matching the requested coolness and size
+   * @param coolness how cool it is
+   * @param size the number of tents
+   * @param nickname a friendly name for the camping
+   */
+  @query
+  def getByCoolnessAndSize(coolness: String, size: Option[Int], nickname: String): Future[Either[String, List[Camping]]]
+
+  /**
+   * get campings matching the requested size and distance
+   * @param size the number of tents
+   * @param distance how distant it is
+   */
+  @query
+  def getBySizeAndDistance(size: Int, distance: Int): Future[Either[String, List[Camping]]]
+
+  /**
+   * get a camping by id
+   * @param id camping id
+   */
+  @token
+  @query
+  def getById(id: Int): Future[Either[String, Camping]]
+
+  /**
+   * get a camping by typed id
+   */
+  @token
+  @query
+  def getByTypedId(id: `Id`[Camping]): Future[Either[String, Camping]]
+
+  /**
+   * get campings based on whether they're close to a beach
+   * @param hasBeach whether there's a beach
+   */
+  @query
+  def getByHasBeach(hasBeach: Boolean): Future[Either[String, List[Camping]]]
+
+  /**
+   * create a camping
+   */
+  @command
+  def create(camping: Camping): Future[Either[String, Camping]]
+}
+
+class CampingControllerImpl(implicit
+  executionContext: ExecutionContext
+) extends CampingController {
+
+  @query
+  def getByCoolnessAndSize(coolness: String, size: Int, nickname: String): Future[Either[String, List[Camping]]] = ???
+
+  @query
+  def getBySizeAndDistance(size: Int, distance: Int): Future[Either[String, List[Camping]]] = ???
+
+  @query
+  def getById(id: Int): Future[Either[String, Camping]] = ???
+
+  @query
+  def getByTypedId(id: `Id`[Camping]): Future[Either[String, Camping]] = ???
+
+  @query
+  def getByHasBeach(hasBeach: Boolean): Future[Either[String, List[Camping]]] = ???
+
+  @command
+  def create(camping: Camping): Future[Either[String, Camping]] = ???
+}
+

--- a/extractor/fixture/sources/controllers.scala
+++ b/extractor/fixture/sources/controllers.scala
@@ -8,7 +8,7 @@ import wiro.annotation._
 
 import scala.concurrent.{ Future, ExecutionContext }
 
-@name("campings")
+@path("campings")
 trait CampingController {
   /**
    * get campings matching the requested coolness and size

--- a/extractor/intermediate.scala
+++ b/extractor/intermediate.scala
@@ -33,7 +33,9 @@ case class RouteParam(
   name: Option[String],
   tpe: Type,
   required: Boolean,
-  desc: Option[String])
+  desc: Option[String],
+  inBody: Boolean = false
+)
 
 sealed trait RouteSegment
 case object RouteSegment {

--- a/extractor/main.scala
+++ b/extractor/main.scala
@@ -7,6 +7,7 @@ import org.rogach.scallop._
 class CommandLine(args: Array[String]) extends ScallopConf(args) {
   val configPath = opt[String]("config", descr = "config file path", required = false)
   val outputFile = opt[String]("output", descr = "output file path", required = false)
+  val wiro = opt[Boolean]("wiro", descr = "parse wiro-style", required = false)
   val directories = trailArg[List[String]](required = true)
   verify()
 }
@@ -42,10 +43,13 @@ object main {
       eval.apply(new File(fileName)) : Config
     }.getOrElse(DefaultConfig)
 
+    val wiro = conf.wiro.get.getOrElse(false)
+
     val api = extractors.extractFullAPI(parsed,
       config.routeOverrides,
       config.routeMatcherToIntermediate,
-      config.authRouteTermNames
+      config.authRouteTermNames,
+      wiro
     ).stripUnusedModels(config.modelsForciblyInUse)
 
     val serializedAPI = repr.serializeAPI(api)

--- a/extractor/src/test/scala/MainSuite.scala
+++ b/extractor/src/test/scala/MainSuite.scala
@@ -9,4 +9,10 @@ class MainSuite extends FunSuite {
     main.main("--config fixture/config.scala fixture/sources".split(" "))
   }
 
+  test("run main with wiro flag") {
+    import morpheus.intermediate._
+
+    main.main("--wiro --config fixture/config.scala fixture/sources".split(" "))
+  }
+
 }

--- a/extractor/src/test/scala/extractors/ApiSuite.scala
+++ b/extractor/src/test/scala/extractors/ApiSuite.scala
@@ -8,20 +8,35 @@ class ApiSuite extends FunSuite {
     import scala.meta.dialects.Scala211
     List(
       morpheus.Fixtures.models.parse[Source].get,
-      morpheus.Fixtures.routes.parse[Source].get
+      morpheus.Fixtures.routes.parse[Source].get,
+      morpheus.Fixtures.controllers.parse[Source].get
     )
   }
 
   test("extract used models") {
     import morpheus.intermediate._
 
-    val api = extractFullAPI(parsed, Common.overrides, Common.routeMatcherToTpe, Common.authRouteTermNames)
+    val api = extractFullAPI(parsed, Common.overrides, Common.routeMatcherToTpe, Common.authRouteTermNames, wiro = false)
       .stripUnusedModels(Common.modelsForciblyInUse)
 
     assert(api.models.collectFirst {
       case CaseEnum("CampingLocation", _, _) => ()
     }.isDefined)
 
+  }
+
+  test("extract wiro style") {
+    import morpheus.intermediate._
+
+    val api = extractFullAPI(parsed, Common.overrides, Common.routeMatcherToTpe, Common.authRouteTermNames, wiro = true)
+      .stripUnusedModels(Common.modelsForciblyInUse)
+
+    assert(api.routes.collectFirst {
+      case Route(get, List(
+        RouteSegment.String("campings"),
+        RouteSegment.String("getByCoolnessAndSize")
+      ), _, _, _, _, _, _, _) => ()
+    }.isDefined)
   }
 
 }

--- a/extractor/src/test/scala/extractors/ControllerSuite.scala
+++ b/extractor/src/test/scala/extractors/ControllerSuite.scala
@@ -163,7 +163,7 @@ class ControllerSuite extends FunSuite {
           ),
           authenticated = false,
           returns = Type.Name("Camping"),
-          body = None, // TODO: Some(Route.Body(Type.Name("Camping"),None)),
+          body = None,
           ctrl = List("campingController", "create"),
           desc = Some("create a camping"),
           name = List("campingController", "create")

--- a/extractor/src/test/scala/extractors/ControllerSuite.scala
+++ b/extractor/src/test/scala/extractors/ControllerSuite.scala
@@ -1,0 +1,176 @@
+package morpheus.extractors
+package controller
+
+import org.scalatest._
+
+class ControllerSuite extends FunSuite {
+  lazy val parsed = {
+    import scala.meta._
+    import scala.meta.dialects.Scala211
+    morpheus.Fixtures.controllers.parse[Source].get
+  }
+
+  test("parse successfully") {
+    parsed
+  }
+
+  test("extract routes from fixture code") {
+    import morpheus.intermediate._
+
+    val models = model.extractModel(parsed)
+    val caseClasses = models.collect { case x: morpheus.intermediate.CaseClass => x }
+    val result = extractAllRoutes(parsed)
+
+    assert(result.toString ===
+      List(
+        Route(
+          method = "get",
+          route = List(
+            RouteSegment.String("campings"),
+            RouteSegment.String("getByCoolnessAndSize")
+          ),
+          params = List(
+            RouteParam(
+              Some("coolness"),
+              Type.Name("String"),
+              true,
+              Some("how cool it is")
+            ),
+            RouteParam(
+              Some("size"),
+              Type.Name("Int"),
+              false,
+              Some("the number of tents")
+            ),
+            RouteParam(
+              Some("nickname"),
+              Type.Name("String"),
+              true,
+              Some("a friendly name for the camping")
+            )
+          ),
+          authenticated = false,
+          returns = Type.Apply("List", List(Type.Name("Camping"))),
+          body = None,
+          ctrl = List("campingController", "getByCoolnessAndSize"),
+          desc = Some("get campings matching the requested coolness and size"),
+          name = List("campingController", "getByCoolnessAndSize")
+        ),
+        Route(
+          method = "get",
+          route = List(
+            RouteSegment.String("campings"),
+            RouteSegment.String("getBySizeAndDistance")
+          ),
+          params = List(
+            RouteParam(
+              Some("size"),
+              Type.Name("Int"),
+              true,
+              Some("the number of tents")
+            ),
+            RouteParam(
+              Some("distance"),
+              Type.Name("Int"),
+              true,
+              Some("how distant it is")
+            )
+          ),
+          authenticated = false,
+          returns = Type.Apply("List", List(Type.Name("Camping"))),
+          body = None,
+          ctrl = List("campingController", "getBySizeAndDistance"),
+          desc = Some("get campings matching the requested size and distance"),
+          name = List("campingController", "getBySizeAndDistance")
+        ),
+        Route(
+          method = "get",
+          route = List(
+            RouteSegment.String("campings"),
+            RouteSegment.String("getById")
+          ),
+          params = List(
+            RouteParam(
+              Some("id"),
+              Type.Name("Int"),
+              true,
+              Some("camping id")
+            )
+          ),
+          authenticated = true,
+          returns = Type.Name("Camping"),
+          body = None,
+          ctrl = List("campingController", "getById"),
+          desc = Some("get a camping by id"),
+          name = List("campingController", "getById")
+        ),
+        Route(
+          method = "get",
+          route = List(
+            RouteSegment.String("campings"),
+            RouteSegment.String("getByTypedId")
+          ),
+          params = List(
+            RouteParam(
+              Some("id"),
+              Type.Apply("Id", Seq(Type.Name("Camping"))),
+              true,
+              None
+            )
+          ),
+          authenticated = true,
+          returns = Type.Name("Camping"),
+          body = None,
+          ctrl = List("campingController", "getByTypedId"),
+          desc = Some("get a camping by typed id"),
+          name = List("campingController", "getByTypedId")
+        ),
+        Route(
+          method = "get",
+          route = List(
+            RouteSegment.String("campings"),
+            RouteSegment.String("getByHasBeach")
+          ),
+          params = List(
+            RouteParam(
+              Some("hasBeach"),
+              Type.Name("Boolean"),
+              true,
+              Some("whether there's a beach")
+            )
+          ),
+          authenticated = false,
+          returns = Type.Apply("List", List(Type.Name("Camping"))),
+          body = None,
+          ctrl = List("campingController", "getByHasBeach"),
+          desc = Some("get campings based on whether they're close to a beach"),
+          name = List("campingController", "getByHasBeach")
+        ),
+        Route(
+          method = "post",
+          route = List(
+            RouteSegment.String("campings"),
+            RouteSegment.String("create")
+          ),
+          params = List(
+            RouteParam(
+              Some("camping"),
+              Type.Name("Camping"),
+              true,
+              None,
+              inBody = true
+            )
+          ),
+          authenticated = false,
+          returns = Type.Name("Camping"),
+          body = None, // TODO: Some(Route.Body(Type.Name("Camping"),None)),
+          ctrl = List("campingController", "create"),
+          desc = Some("create a camping"),
+          name = List("campingController", "create")
+        )
+      ).toString
+    )
+
+  }
+}
+

--- a/extractor/src/test/scala/fixtures.scala
+++ b/extractor/src/test/scala/fixtures.scala
@@ -3,4 +3,5 @@ package morpheus
 object Fixtures {
   val models = morpheus.util.slurp("fixture/sources/models.scala")
   val routes = morpheus.util.slurp("fixture/sources/routes.scala")
+  val controllers = morpheus.util.slurp("fixture/sources/controllers.scala")
 }


### PR DESCRIPTION
Adds support for wiro applications, where routers are implicitly generated by the controllers.

This PR adds support for parsing the controllers and generating the same intermediate representation as the one extracted from the routers.

There should be no breaking changes introduced by this PR (previous tests are all green) as wiro support is provided under a flag (`--wiro`).