### PR TITLE
Config json

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,7 +52,9 @@ lazy val cli = project
     libraryDependencies ++= Seq(
       "org.rogach" %% "scallop" % "1.0.0",
       "org.json4s" %% "json4s-jackson" % "3.5.0",
-      "com.twitter" %% "util-eval" % "6.41.0",
+      "io.circe" %% "circe-core" % "0.8.0",
+      "io.circe" %% "circe-generic-extras" % "0.8.0",
+      "io.circe" %% "circe-parser" % "0.8.0",
       "org.scalatest" %% "scalatest" % "3.0.1" % Test
     )
   )

--- a/cli/src/test/resources/fixtures/config.json
+++ b/cli/src/test/resources/fixtures/config.json
@@ -1,0 +1,3 @@
+{
+  "authRouteTermNames": ["withUserAuthentication", "withRole"]
+}

--- a/cli/src/test/resources/fixtures/config.scala
+++ b/cli/src/test/resources/fixtures/config.scala
@@ -1,3 +1,0 @@
-new io.buildo.metarpheus.core.Config {
-  override val authRouteTermNames = List("withUserAuthentication", "withRole")
-}

--- a/cli/src/test/resources/fixtures/config.scala
+++ b/cli/src/test/resources/fixtures/config.scala
@@ -1,24 +1,3 @@
 new io.buildo.metarpheus.core.Config {
-  import io.buildo.metarpheus.core.intermediate._
-
-  val routeMatcherToIntermediate = PartialFunction[(String, Option[Type]), Type] {
-    case ("Id", Some(x@Type.Name(_))) => Type.Apply("Id", Seq(x))
-  }
-
-  override val routeOverrides = Map(
-    List("campingController", "overridden") -> Route(
-      method = "get",
-      route = List(
-        RouteSegment.String("something")
-      ),
-      params = List(),
-      authenticated = false,
-      returns = Type.Apply("List", List(Type.Name("Something"))),
-      body = None,
-      ctrl = List("campingController", "something"),
-      desc = Some("gets something"),
-      name = List("campingController", "overridden")
-    ))
-
   override val authRouteTermNames = List("withUserAuthentication", "withRole")
 }

--- a/cli/src/test/scala/io.buildo.metarpheus/cli/CliSuite.scala
+++ b/cli/src/test/scala/io.buildo.metarpheus/cli/CliSuite.scala
@@ -6,11 +6,11 @@ import org.scalatest._
 
 class CliSuite extends FunSuite {
   test("run main") {
-    Cli.main("--config cli/src/test/resources/fixtures/config.scala core/src/test/resources/fixtures".split(" "))
+    Cli.main("--config cli/src/test/resources/fixtures/config.json core/src/test/resources/fixtures".split(" "))
   }
 
   test("run main with wiro flag") {
-    Cli.main("--wiro --config cli/src/test/resources/fixtures/config.scala core/src/test/resources/fixtures".split(" "))
+    Cli.main("--wiro --config cli/src/test/resources/fixtures/config.json core/src/test/resources/fixtures".split(" "))
   }
 
 }

--- a/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
+++ b/core/src/main/scala/io.buildo.metarpheus/core/Metarpheus.scala
@@ -6,14 +6,12 @@ import scala.meta.inputs.Input
 
 object Metarpheus {
 
-  def run(files: List[String], config: Config, wiro: Boolean): intermediate.API = {
+  def run(files: List[String], config: Config): intermediate.API = {
     val parsed = files.map(Input.String(_).parse[Source].get)
     extractors.extractFullAPI(
       parsed = parsed,
-      routeOverrides = config.routeOverrides,
-      routeMatcherToIntermediate = config.routeMatcherToIntermediate,
       authRouteTermNames = config.authRouteTermNames,
-      wiro = wiro
+      wiro = config.wiro
     )
   }
 

--- a/core/src/main/scala/io.buildo.metarpheus/core/config.scala
+++ b/core/src/main/scala/io.buildo.metarpheus/core/config.scala
@@ -1,17 +1,12 @@
 package io.buildo.metarpheus
 package core
 
-import io.circe._
-import io.circe.generic.auto._
-import io.circe.syntax._
-
 case class Config(
   authRouteTermNames: List[String] = Nil,
   modelsForciblyInUse: Set[String] = Set.empty,
   wiro: Boolean = false
-) extends LegacyConfig
+)
 
-trait LegacyConfig {
-  val routeOverrides: Map[List[String], intermediate.Route] = Map.empty
-  val routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type] = PartialFunction.empty
+object Config {
+  val default: Config = Config()
 }

--- a/core/src/main/scala/io.buildo.metarpheus/core/config.scala
+++ b/core/src/main/scala/io.buildo.metarpheus/core/config.scala
@@ -1,17 +1,17 @@
 package io.buildo.metarpheus
 package core
 
-trait Config {
-  val routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type]
+import io.circe._
+import io.circe.generic.auto._
+import io.circe.syntax._
 
-  val routeOverrides: Map[List[String], intermediate.Route] = Map()
+case class Config(
+  authRouteTermNames: List[String] = Nil,
+  modelsForciblyInUse: Set[String] = Set.empty,
+  wiro: Boolean = false
+) extends LegacyConfig
 
-  val authRouteTermNames: List[String] = Nil
-
-  val modelsForciblyInUse: Set[String] = Set.empty
-}
-
-object DefaultConfig extends Config {
-  val routeMatcherToIntermediate = PartialFunction.empty
-  override val authRouteTermNames = List("withUserAuthentication")
+trait LegacyConfig {
+  val routeOverrides: Map[List[String], intermediate.Route] = Map.empty
+  val routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type] = PartialFunction.empty
 }

--- a/core/src/main/scala/io.buildo.metarpheus/core/extractors/package.scala
+++ b/core/src/main/scala/io.buildo.metarpheus/core/extractors/package.scala
@@ -8,8 +8,6 @@ package object extractors {
 
   def extractFullAPI(
     parsed: List[scala.meta.Source],
-    routeOverrides: Map[List[String], intermediate.Route],
-    routeMatcherToIntermediate: PartialFunction[(String, Option[intermediate.Type]), intermediate.Type],
     authRouteTermNames: List[String],
     wiro: Boolean
   ): intermediate.API = {
@@ -24,7 +22,7 @@ package object extractors {
       if (wiro) {
         parsed.flatMap(extractors.controller.extractAllRoutes)
       } else {
-        parsed.flatMap(extractors.route.extractAllRoutes(caseClasses, routeOverrides, routeMatcherToIntermediate, authRouteTermNames))
+        parsed.flatMap(extractors.route.extractAllRoutes(caseClasses, authRouteTermNames))
       }
 
     intermediate API(models, routes)
@@ -56,6 +54,11 @@ package object extractors {
     case scala.meta.Type.Apply(name: scala.meta.Type.Name, args) =>
       intermediate.Type.Apply(name.value, args.map(tpeToIntermediate))
     case scala.meta.Type.Select(_, t) => tpeToIntermediate(t)
+  }
+
+  private[extractors] def tpeToIntermediate(t: Term.ApplyType): intermediate.Type = t match {
+    case Term.ApplyType(name: Term.Name, targs) =>
+      intermediate.Type.Apply(name.value, t.targs.map(tpeToIntermediate))
   }
 
   private[extractors] def stripCommentMarkers(s: String) =

--- a/core/src/test/resources/fixtures/routes.scala
+++ b/core/src/test/resources/fixtures/routes.scala
@@ -61,10 +61,6 @@ trait CampingRouterModule extends io.buildo.base.MonadicCtrlRouterModule
       (post & pathEnd & entity(as[Camping]) /**
         create a camping
       */) (returns[Camping].ctrl(campingController.create _)) ~
-      (get & path("overridable") & something /**
-        overridable route
-        @name campingController.overridden
-      */) (returns[Camping].ctrl(campingController.something _)) ~
       withRole(Admin) { user =>
         (get & path("by_query") & params[GetByQueryParams] /**
           get multiple campings by params with case class

--- a/core/src/test/scala/io.buildo.metarpheus/core/extractors/ApiSuite.scala
+++ b/core/src/test/scala/io.buildo.metarpheus/core/extractors/ApiSuite.scala
@@ -20,7 +20,7 @@ class ApiSuite extends FunSuite {
   test("extract used models") {
     import intermediate._
 
-    val api = extractFullAPI(parsed, Common.overrides, Common.routeMatcherToTpe, Common.authRouteTermNames, wiro = false)
+    val api = extractFullAPI(parsed, Common.authRouteTermNames, wiro = false)
       .stripUnusedModels(Common.modelsForciblyInUse)
 
     assert(api.models.collectFirst {
@@ -32,7 +32,7 @@ class ApiSuite extends FunSuite {
   test("extract wiro style") {
     import intermediate._
 
-    val api = extractFullAPI(parsed, Common.overrides, Common.routeMatcherToTpe, Common.authRouteTermNames, wiro = true)
+    val api = extractFullAPI(parsed, Common.authRouteTermNames, wiro = true)
       .stripUnusedModels(Common.modelsForciblyInUse)
 
     assert(api.routes.collectFirst {

--- a/core/src/test/scala/io.buildo.metarpheus/core/extractors/Common.scala
+++ b/core/src/test/scala/io.buildo.metarpheus/core/extractors/Common.scala
@@ -5,32 +5,6 @@ package test
 import intermediate._
 
 object Common {
-    val overridableOverride = Route(
-      method = "get",
-      route = List(
-        RouteSegment.String("something")
-      ),
-      params = List(),
-      authenticated = false,
-      returns = Type.Apply("List", List(Type.Name("Something"))),
-      body = None,
-      ctrl = List("campingController", "something"),
-      desc = Some("gets something"),
-      name = List("campingController", "overridden")
-    )
-
-    val overrides = Map(
-      List("campingController", "overridden") -> overridableOverride
-    )
-
-    /**
-     * Convert a spray route matcher to the corresponding resulting type
-     */
-    def routeMatcherToTpe = PartialFunction[(String, Option[Type]), Type] {
-      case ("Id", Some(x@Type.Name(_))) => Type.Apply("Id", Seq(x))
-    }
-
     val authRouteTermNames = List("withUserAuthentication", "withRole")
-
     val modelsForciblyInUse = Set("Swan")
 }

--- a/core/src/test/scala/io.buildo.metarpheus/core/extractors/RouteSuite.scala
+++ b/core/src/test/scala/io.buildo.metarpheus/core/extractors/RouteSuite.scala
@@ -21,7 +21,7 @@ class RouteSuite extends FunSuite {
 
     val models = model.extractModel(parsed)
     val caseClasses = models.collect { case x: CaseClass => x }
-    val result = route.extractAllRoutes(caseClasses, Common.overrides, Common.routeMatcherToTpe, Common.authRouteTermNames)(parsed)
+    val result = route.extractAllRoutes(caseClasses, Common.authRouteTermNames)(parsed)
 
     assert(result.toString ===
       List(
@@ -154,7 +154,6 @@ class RouteSuite extends FunSuite {
           desc = Some("create a camping"),
           name = List("campingController", "create")
         ),
-        Common.overridableOverride,
         Route(
           method = "get",
           route = List(


### PR DESCRIPTION
This PR turns the configuration into a static JSON file, instead of an interpreted Scala file.

For this to happen, two "dynamic" settings had to go: `routeOverrides` and `routeMatcherToIntermediate`. Thankfully, they have never been used in any of our projects, so we won't miss them.

Having a static configuration is yet another step towards scala.js compatibility.